### PR TITLE
Added posterImg function

### DIFF
--- a/gp.php
+++ b/gp.php
@@ -1,5 +1,4 @@
 <?php
-
 function curl($url) {
 	$ch = @curl_init();
 	curl_setopt($ch, CURLOPT_URL, $url);
@@ -20,7 +19,30 @@ function curl($url) {
 	curl_close($ch);
 	return $page;
 }
-
+function posterImg($url) {
+$internalErrors = libxml_use_internal_errors(true);
+$ch = curl_init();
+$timeout = 25;
+curl_setopt($ch, CURLOPT_URL, $url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
+$html = curl_exec($ch);
+curl_close($ch);
+$dom = new DOMDocument();
+@$dom->loadHTML($html);
+libxml_use_internal_errors($internalErrors);
+$maximgx = 1;
+$imgx = "";
+foreach($dom->getElementsByTagName('img') as $element) {
+    if ($maximgx <= 1) {
+    $imgx = $element->getAttribute('src');
+    $maximgx++;
+    }
+}
+ $xim = str_replace("=w214-h120-k-no","=w1280-h720-no",$imgx);
+ $posterx = $xim;
+return $posterx;    
+}
 function getPhotoGoogle($link){
 	$get = curl($link);
 	$data = explode('url\u003d', $get);

--- a/gp.php
+++ b/gp.php
@@ -19,7 +19,7 @@ function curl($url) {
 	curl_close($ch);
 	return $page;
 }
-function posterImg($url) {
+function posterImg($url, $size = "1280,720") { //poster size width,height
 $internalErrors = libxml_use_internal_errors(true);
 $ch = curl_init();
 $timeout = 25;
@@ -28,6 +28,7 @@ curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
 $html = curl_exec($ch);
 curl_close($ch);
+$sizes = explode(",",$size);
 $dom = new DOMDocument();
 @$dom->loadHTML($html);
 libxml_use_internal_errors($internalErrors);
@@ -39,7 +40,7 @@ foreach($dom->getElementsByTagName('img') as $element) {
     $maximgx++;
     }
 }
- $xim = str_replace("=w214-h120-k-no","=w1280-h720-no",$imgx);
+ $xim = str_replace("=w214-h120-k-no","=w".$sizes[0]."-h".$sizes[1]."-no",$imgx);
  $posterx = $xim;
 return $posterx;    
 }

--- a/gp.php
+++ b/gp.php
@@ -22,7 +22,7 @@ function curl($url) {
 function posterImg($url, $size = "1280,720") { //poster size width,height
 $internalErrors = libxml_use_internal_errors(true);
 $ch = curl_init();
-$timeout = 25;
+$timeout = 30;
 curl_setopt($ch, CURLOPT_URL, $url);
 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
 curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
@@ -35,14 +35,10 @@ libxml_use_internal_errors($internalErrors);
 $maximgx = 1;
 $imgx = "";
 foreach($dom->getElementsByTagName('img') as $element) {
-    if ($maximgx <= 1) {
-    $imgx = $element->getAttribute('src');
-    $maximgx++;
-    }
+($maximgx <= 1) ? $maximgx++ && $imgx = $element->getAttribute('src') : ''; 
 }
- $xim = str_replace("=w214-h120-k-no","=w".$sizes[0]."-h".$sizes[1]."-no",$imgx);
- $posterx = $xim;
-return $posterx;    
+$xim = str_replace("=w214-h120-k-no","=w".$sizes[0]."-h".$sizes[1]."-no",$imgx);
+return $xim;    
 }
 function getPhotoGoogle($link){
 	$get = curl($link);


### PR DESCRIPTION
You can use posterImg function with optional sizes. Default size is 1280,720
```php
$poster = posterImg('https://photos.google.com/share/AF1QipMTEPAiVF8t0YqLukflnOSQjwfd8ARIoT2h37AXvYO1uaWodbeiFoBUDuD_19tEbg/photo/AF1QipPA2Bq0JlAR9LoGD3mogsxSb9OZWEG4XqBDD4Rv?key=cjhUT0xrZjM5NGN2SVRLOVptZU5SMUlKV0lQYWpB', "1980,1080"); //width,height
```